### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/ci-cd-non-release.yml
+++ b/.github/workflows/ci-cd-non-release.yml
@@ -70,6 +70,9 @@ jobs:
         with:
           name: maven-target
           path: target
+      
+      - name: Run Integration Tests
+        run: mvn -B -ntp failsafe:integration-test failsafe:verify -Drevision=${{ needs.revision.outputs.revision }}
 
       - name: Publish reports
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -68,6 +68,9 @@ jobs:
           name: maven-target
           path: target
 
+      - name: Run Integration Tests
+        run: mvn -B -ntp failsafe:integration-test failsafe:verify -Drevision=${{ needs.revision.outputs.revision }}
+
       - name: Publish reports
         if: always() && github.event_name == 'pull_request'
         uses: unir-tfm-devops/reusable-github-actions/.github/actions/mvn-failsafe-surefire-report@main

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <jacoco.version>0.8.13</jacoco.version>
     <spotless.version>2.44.5</spotless.version>
+    <testcontainers.version>1.21.0</testcontainers.version>
+    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
   </properties>
 
   <dependencies>
@@ -80,6 +83,21 @@
       <groupId>org.instancio</groupId>
       <artifactId>instancio-junit</artifactId>
       <version>${instancio.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Test Containers -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -153,6 +171,47 @@
           <java>
             <googleJavaFormat/>
           </java>
+        </configuration>
+      </plugin>
+
+      <!-- Maven Surefire Plugin - for unit tests only -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId> 
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*Tests.java</include>
+            <include>**/Test*.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*IT.java</exclude>
+            <exclude>**/IT*.java</exclude>
+            <exclude>**/*ITCase.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <!-- Maven Failsafe Plugin - for integration tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+            <include>**/IT*.java</include>
+            <include>**/*ITCase.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/java/com/unir/template/it/BooksRepositoryIT.java
+++ b/src/test/java/com/unir/template/it/BooksRepositoryIT.java
@@ -1,0 +1,197 @@
+package com.unir.template.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.unir.template.model.Book;
+import com.unir.template.repository.BooksRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+class BooksRepositoryIT {
+
+  @Container
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:15-alpine")
+          .withDatabaseName("test_db")
+          .withUsername("test_user")
+          .withPassword("test_password");
+
+  @DynamicPropertySource
+  static void configureProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+  }
+
+  @Autowired private BooksRepository booksRepository;
+
+  @BeforeEach
+  void setUp() {
+    booksRepository.deleteAll();
+  }
+
+  @Test
+  void givenBook_whenSave_thenBookIsSaved() {
+    // Given
+    Book book =
+        Book.builder()
+            .name("Test Book")
+            .description("Test Description")
+            .price(29.99)
+            .stock(10)
+            .build();
+
+    // When
+    Book savedBook = booksRepository.save(book);
+
+    // Then
+    assertThat(savedBook).isNotNull();
+    assertThat(savedBook.getId()).isNotNull();
+    assertThat(savedBook.getName()).isEqualTo("Test Book");
+    assertThat(savedBook.getDescription()).isEqualTo("Test Description");
+    assertThat(savedBook.getPrice()).isEqualTo(29.99);
+    assertThat(savedBook.getStock()).isEqualTo(10);
+  }
+
+  @Test
+  void givenSavedBook_whenFindById_thenBookIsFound() {
+    // Given
+    Book book =
+        Book.builder()
+            .name("Test Book")
+            .description("Test Description")
+            .price(29.99)
+            .stock(10)
+            .build();
+    Book savedBook = booksRepository.save(book);
+
+    // When
+    Optional<Book> foundBook = booksRepository.findById(savedBook.getId());
+
+    // Then
+    assertThat(foundBook).isPresent();
+    assertThat(foundBook.get().getName()).isEqualTo("Test Book");
+  }
+
+  @Test
+  void givenMultipleBooks_whenFindAll_thenAllBooksAreReturned() {
+    // Given
+    Book book1 =
+        Book.builder().name("Book 1").description("Description 1").price(19.99).stock(5).build();
+
+    Book book2 =
+        Book.builder().name("Book 2").description("Description 2").price(39.99).stock(15).build();
+
+    booksRepository.save(book1);
+    booksRepository.save(book2);
+
+    // When
+    List<Book> allBooks = booksRepository.findAll();
+
+    // Then
+    assertThat(allBooks).hasSize(2);
+    assertThat(allBooks).extracting("name").containsExactlyInAnyOrder("Book 1", "Book 2");
+  }
+
+  @Test
+  void givenSavedBook_whenUpdate_thenBookIsUpdated() {
+    // Given
+    Book book =
+        Book.builder()
+            .name("Original Name")
+            .description("Original Description")
+            .price(25.00)
+            .stock(5)
+            .build();
+    Book savedBook = booksRepository.save(book);
+
+    // When
+    savedBook.setName("Updated Name");
+    savedBook.setPrice(35.00);
+    Book updatedBook = booksRepository.save(savedBook);
+
+    // Then
+    assertThat(updatedBook.getName()).isEqualTo("Updated Name");
+    assertThat(updatedBook.getPrice()).isEqualTo(35.00);
+    assertThat(updatedBook.getId()).isEqualTo(savedBook.getId());
+  }
+
+  @Test
+  void givenSavedBook_whenDeleteById_thenBookIsDeleted() {
+    // Given
+    Book book =
+        Book.builder()
+            .name("Book to Delete")
+            .description("Description")
+            .price(20.00)
+            .stock(3)
+            .build();
+    Book savedBook = booksRepository.save(book);
+
+    // When
+    booksRepository.deleteById(savedBook.getId());
+
+    // Then
+    Optional<Book> deletedBook = booksRepository.findById(savedBook.getId());
+    assertThat(deletedBook).isEmpty();
+  }
+
+  @Test
+  void givenNonExistentBookId_whenFindById_thenEmptyIsReturned() {
+    // When
+    Optional<Book> notFoundBook = booksRepository.findById(UUID.randomUUID());
+
+    // Then
+    assertThat(notFoundBook).isEmpty();
+  }
+
+  @Test
+  void givenMultipleBooks_whenCount_thenCorrectCountIsReturned() {
+    // Given
+    Book book1 =
+        Book.builder().name("Book 1").description("Description 1").price(19.99).stock(5).build();
+
+    Book book2 =
+        Book.builder().name("Book 2").description("Description 2").price(39.99).stock(15).build();
+
+    booksRepository.save(book1);
+    booksRepository.save(book2);
+
+    // When
+    long count = booksRepository.count();
+
+    // Then
+    assertThat(count).isEqualTo(2);
+  }
+
+  @Test
+  void givenSavedBook_whenExistsById_thenReturnsTrue() {
+    // Given
+    Book book =
+        Book.builder()
+            .name("Test Book")
+            .description("Test Description")
+            .price(29.99)
+            .stock(10)
+            .build();
+    Book savedBook = booksRepository.save(book);
+
+    // When & Then
+    assertThat(booksRepository.existsById(savedBook.getId())).isTrue();
+    assertThat(booksRepository.existsById(UUID.randomUUID())).isFalse();
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: spring-boot-template-test
+
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+server:
+  port: 0


### PR DESCRIPTION
This pull request introduces integration tests using Testcontainers and Maven Failsafe Plugin, along with necessary configuration updates to support these tests. It also includes the addition of a comprehensive integration test class for the `BooksRepository`. The most important changes are grouped below:

### Integration Tests Setup:
* `.github/workflows/ci-cd-non-release.yml` and `.github/workflows/ci-cd-pr.yml`: Added a new step to run integration tests using Maven Failsafe Plugin in the CI/CD workflows. [[1]](diffhunk://#diff-0fa466fa8dddc67484c44df7a6bdfa463120cb83b8e292a09dd3f3cca59ba7bcR74-R76) [[2]](diffhunk://#diff-351e1259ecf68449f05d85305523ebd7038a500b496611099a1cb93d02106ab1R71-R73)
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R28-R30): Added dependencies for Testcontainers (`junit-jupiter` and `postgresql`) and configured Maven Surefire and Failsafe Plugins for unit and integration tests respectively. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R28-R30) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R88-R102) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R176-R216)

### Integration Test Implementation:
* [`src/test/java/com/unir/template/it/BooksRepositoryIT.java`](diffhunk://#diff-c8ca3b1cce7930ed077429f4092e9952eca5e268b51ca43a67c35dd5f62f1864R1-R197): Created a new integration test class for `BooksRepository` using Testcontainers to dynamically manage a PostgreSQL database for testing. Includes multiple test cases covering CRUD operations and repository methods.

### Test Configuration:
* [`src/test/resources/application-test.yml`](diffhunk://#diff-3d17508f6ed3b2bf957c725741cde10edeb229b40b8c3cecf57e7dc5ce78ede6R1-R18): Added a new Spring Boot test profile configuration file to specify database settings, Hibernate dialect, and other properties for integration tests.