### PR TITLE
Update reusable workflows

### DIFF
--- a/.github/workflows/ci-cd-non-release.yml
+++ b/.github/workflows/ci-cd-non-release.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   ci-cd:
     name: CI/CD
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd-non-release.yml@main
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd/spring-boot/ci-cd-non-release.yml@main
     with:
       image-repo-name: "spring-boot-template"
       app-name: "spring-boot-template"

--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -10,5 +10,5 @@ concurrency:
 jobs:
   ci-cd:
     name: CI/CD
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd-pr.yml@main
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd/spring-boot/ci-cd-pr.yml@main
     secrets: inherit

--- a/.github/workflows/ci-cd-release.yml
+++ b/.github/workflows/ci-cd-release.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   ci-cd:
     name: CI/CD
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd-release.yml@main
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd/spring-boot/ci-cd-release.yml@main
     with:
       image-repo-name: "spring-boot-template"
       app-name: "spring-boot-template"

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -11,5 +11,5 @@ concurrency:
 jobs:
   pr-checks:
     name: PR format
-    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/pr-checks.yml@main
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/shared/pr-checks.yml@main
     secrets: inherit


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use more specific paths for reusable actions, aligning them with the appropriate project structure and improving organization.

Updates to GitHub Actions workflow paths:

* [`.github/workflows/ci-cd-non-release.yml`](diffhunk://#diff-0fa466fa8dddc67484c44df7a6bdfa463120cb83b8e292a09dd3f3cca59ba7bcL16-R16): Updated the reusable action path to `ci-cd/spring-boot/ci-cd-non-release.yml` for better alignment with the Spring Boot project structure.
* [`.github/workflows/ci-cd-pr.yml`](diffhunk://#diff-351e1259ecf68449f05d85305523ebd7038a500b496611099a1cb93d02106ab1L13-R13): Changed the reusable action path to `ci-cd/spring-boot/ci-cd-pr.yml` for consistency with the Spring Boot project.
* [`.github/workflows/ci-cd-release.yml`](diffhunk://#diff-eb916f5872ac32dfa026157008d60d7b1ae37d966de3333b2212d008f2c4ca2cL14-R14): Adjusted the reusable action path to `ci-cd/spring-boot/ci-cd-release.yml` to match the Spring Boot template.
* [`.github/workflows/pr-checklist.yml`](diffhunk://#diff-4e4b2ad5c6fa82f1766f5db891ba82212b416dd184c4000f4e610a5f05b11c75L14-R14): Updated the reusable action path to `shared/pr-checks.yml` to use a shared configuration for PR checks.